### PR TITLE
Adding support for Running on auxiliary I2C

### DIFF
--- a/BMI160Gen.cpp
+++ b/BMI160Gen.cpp
@@ -12,7 +12,7 @@ bool BMI160GenClass::begin(const int spi_cs_pin, const int intr_pin)
 bool BMI160GenClass::begin(Mode mode, TwoWire &wirePort,const int arg1, const int arg2)
 {
     this->mode = mode;
-	i2cPort = &wirePort;
+	_i2cPort = &wirePort;
     switch (this->mode) {
     case INVALID_MODE:
         return false;
@@ -81,9 +81,9 @@ void BMI160GenClass::i2c_init()
   Serial.println("BMI160GenClass::i2c_init()...");
 #endif // DEBUG
 
-  //i2cPort->begin();
-  i2cPort->beginTransmission(i2c_addr);
-  if( i2cPort->endTransmission() != 0 )
+  //_i2cPort->begin();
+  _i2cPort->beginTransmission(i2c_addr);
+  if( _i2cPort->endTransmission() != 0 )
       Serial.println("BMI160GenClass::i2c_init(): I2C failed.");
 
 #ifdef DEBUG
@@ -108,26 +108,26 @@ int BMI160GenClass::i2c_xfer(uint8_t *buf, unsigned tx_cnt, unsigned rx_cnt)
   Serial.print("):");
 #endif // DEBUG
 
-  i2cPort->beginTransmission(i2c_addr);
+  _i2cPort->beginTransmission(i2c_addr);
   p = buf;
   while (0 < tx_cnt) {
     tx_cnt--;
-    i2cPort->write(*p++);
+    _i2cPort->write(*p++);
   }
-  if( i2cPort->endTransmission() != 0 ) {
+  if( _i2cPort->endTransmission() != 0 ) {
       Serial.println("Wire.endTransmission() failed.");
   }
   if (0 < rx_cnt) {
-    i2cPort->requestFrom(i2c_addr, rx_cnt);
+    _i2cPort->requestFrom(i2c_addr, rx_cnt);
     p = buf;
-    while ( i2cPort->available() && 0 < rx_cnt) {
+    while ( _i2cPort->available() && 0 < rx_cnt) {
       rx_cnt--;
 #ifdef DEBUG
-      int t = *p++ = i2cPort->read();
+      int t = *p++ = _i2cPort->read();
       Serial.print(" ");
       Serial.print(t, HEX);
 #else
-      *p++ = i2cPort->read();;
+      *p++ = _i2cPort->read();;
 #endif // DEBUG
     }
   }

--- a/BMI160Gen.cpp
+++ b/BMI160Gen.cpp
@@ -1,17 +1,18 @@
 #include "BMI160Gen.h"
 #include "SPI.h"
-#include "Wire.h"
+
 
 //#define DEBUG
 
 bool BMI160GenClass::begin(const int spi_cs_pin, const int intr_pin)
-{
-    return begin(SPI_MODE, spi_cs_pin, intr_pin);
+{	
+    return begin(SPI_MODE, Wire, spi_cs_pin, intr_pin);
 }
 
-bool BMI160GenClass::begin(Mode mode, const int arg1, const int arg2)
+bool BMI160GenClass::begin(Mode mode, TwoWire &wirePort,const int arg1, const int arg2)
 {
     this->mode = mode;
+	i2cPort = &wirePort;
     switch (this->mode) {
     case INVALID_MODE:
         return false;
@@ -80,9 +81,9 @@ void BMI160GenClass::i2c_init()
   Serial.println("BMI160GenClass::i2c_init()...");
 #endif // DEBUG
 
-  Wire.begin();
-  Wire.beginTransmission(i2c_addr);
-  if( Wire.endTransmission() != 0 )
+  //i2cPort->begin();
+  i2cPort->beginTransmission(i2c_addr);
+  if( i2cPort->endTransmission() != 0 )
       Serial.println("BMI160GenClass::i2c_init(): I2C failed.");
 
 #ifdef DEBUG
@@ -107,26 +108,26 @@ int BMI160GenClass::i2c_xfer(uint8_t *buf, unsigned tx_cnt, unsigned rx_cnt)
   Serial.print("):");
 #endif // DEBUG
 
-  Wire.beginTransmission(i2c_addr);
+  i2cPort->beginTransmission(i2c_addr);
   p = buf;
   while (0 < tx_cnt) {
     tx_cnt--;
-    Wire.write(*p++);
+    i2cPort->write(*p++);
   }
-  if( Wire.endTransmission() != 0 ) {
+  if( i2cPort->endTransmission() != 0 ) {
       Serial.println("Wire.endTransmission() failed.");
   }
   if (0 < rx_cnt) {
-    Wire.requestFrom(i2c_addr, rx_cnt);
+    i2cPort->requestFrom(i2c_addr, rx_cnt);
     p = buf;
-    while ( Wire.available() && 0 < rx_cnt) {
+    while ( i2cPort->available() && 0 < rx_cnt) {
       rx_cnt--;
 #ifdef DEBUG
-      int t = *p++ = Wire.read();
+      int t = *p++ = i2cPort->read();
       Serial.print(" ");
       Serial.print(t, HEX);
 #else
-      *p++ = Wire.read();;
+      *p++ = i2cPort->read();;
 #endif // DEBUG
     }
   }

--- a/BMI160Gen.h
+++ b/BMI160Gen.h
@@ -23,7 +23,7 @@ class BMI160GenClass : public CurieIMUClass {
         void spi_init();
         int spi_xfer(uint8_t *buf, unsigned tx_cnt, unsigned rx_cnt);
 	private:
-		TwoWire *i2cPort;
+		TwoWire *_i2cPort;
 
 };
 

--- a/BMI160Gen.h
+++ b/BMI160Gen.h
@@ -3,12 +3,13 @@
 
 //#define BMI160GEN_USE_CURIEIMU
 #include "CurieIMU.h"
+#include "Wire.h"
 
 class BMI160GenClass : public CurieIMUClass {
     public:
         typedef enum { INVALID_MODE = -1, I2C_MODE = 1, SPI_MODE = 2 } Mode;
         bool begin(const int spi_cs_pin = 10, const int intr_pin = 2);
-        bool begin(Mode mode, const int arg1 = 0x68, const int arg2 = 2);
+        bool begin(Mode mode, TwoWire &wirePort = Wire, const int arg1 = 0x68, const int arg2 = 2);
         void attachInterrupt(void (*callback)(void));
     protected:
         int interrupt_pin = -1;
@@ -21,6 +22,9 @@ class BMI160GenClass : public CurieIMUClass {
         int i2c_xfer(uint8_t *buf, unsigned tx_cnt, unsigned rx_cnt);
         void spi_init();
         int spi_xfer(uint8_t *buf, unsigned tx_cnt, unsigned rx_cnt);
+	private:
+		TwoWire *i2cPort;
+
 };
 
 extern BMI160GenClass BMI160;


### PR DESCRIPTION
You can now pass a TwoWire instance when initializing the sensor. This enables running the sensor on Additional I2C instances created by the user.